### PR TITLE
feat: lockfile v3

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -7,9 +7,9 @@ pub enum LockfileError {
   #[error(transparent)]
   Io(#[from] std::io::Error),
 
-  #[error("Unable to read lockfile: \"{0}\"")]
+  #[error("Unable to read lockfile. {0}")]
   ReadError(String),
 
-  #[error("Unable to parse contents of lockfile: \"{0}\"")]
+  #[error("Unable to parse contents of lockfile. {0}")]
   ParseError(String),
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -184,7 +184,7 @@ impl Lockfile {
       None => transforms::transform1_to_2(transforms::transform2_to_3(value)),
       Some(version) => {
         return Err(Error::ParseError(format!(
-          "Unsupported lockfile version: {}",
+          "Unsupported lockfile version '{}'. Try upgrading Deno or recreating the lockfile.",
           version
         )))
       }
@@ -406,7 +406,7 @@ mod tests {
       )
       .err()
       .unwrap().to_string(),
-      "Unable to parse contents of lockfile. Unsupported lockfile version: 2000".to_string()
+      "Unable to parse contents of lockfile. Unsupported lockfile version '2000'. Try upgrading Deno or recreating the lockfile.".to_string()
     );
   }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -100,18 +100,18 @@ impl NpmContent {
 #[derive(Debug, Clone, Serialize, Deserialize, Hash)]
 pub struct LockfileContent {
   version: String,
-  // order these based on auditability
+  // order these based on auditability (though, right now npm is at the bottom for backwards compat)
   #[serde(skip_serializing_if = "DenoContent::is_empty")]
   #[serde(default)]
   pub deno: DenoContent,
   #[serde(skip_serializing_if = "BTreeMap::is_empty")]
   #[serde(default)]
   pub redirects: BTreeMap<String, String>,
+  /// Mapping between URLs and their checksums for "http:" and "https:" deps
+  remote: BTreeMap<String, String>,
   #[serde(skip_serializing_if = "NpmContent::is_empty")]
   #[serde(default)]
   pub npm: NpmContent,
-  /// Mapping between URLs and their checksums for "http:" and "https:" deps
-  remote: BTreeMap<String, String>,
 }
 
 impl LockfileContent {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -375,8 +375,8 @@ mod tests {
     }
   },
   "remote": {
-    "https://deno.land/std@0.71.0/textproto/mod.ts": "3118d7a42c03c242c5a49c2ad91c8396110e14acca1324e7aaefd31a999b71a4",
-    "https://deno.land/std@0.71.0/async/delay.ts": "35957d585a6e3dd87706858fb1d6b551cb278271b03f52c5a2cb70e65e00c26a"
+    "https://deno.land/std@0.71.0/textproto/mod.ts": "sha512-3118d7a42c03c242c5a49c2ad91c8396110e14acca1324e7aaefd31a999b71a4",
+    "https://deno.land/std@0.71.0/async/delay.ts": "sha512-35957d585a6e3dd87706858fb1d6b551cb278271b03f52c5a2cb70e65e00c26a"
   }
 }"#;
 
@@ -393,6 +393,21 @@ mod tests {
   fn create_lockfile_for_nonexistent_path() {
     let file_path = PathBuf::from("nonexistent_lock_file.json");
     assert!(Lockfile::new(file_path, false).is_ok());
+  }
+
+  #[test]
+  fn future_version_unsupported() {
+    let file_path = PathBuf::from("lockfile.json");
+    assert_eq!(
+      Lockfile::with_lockfile_content(
+        file_path,
+        "{ \"version\": \"2000\" }",
+        false
+      )
+      .err()
+      .unwrap().to_string(),
+      "Unable to parse contents of lockfile. Unsupported lockfile version: 2000".to_string()
+    );
   }
 
   #[test]

--- a/src/transforms.rs
+++ b/src/transforms.rs
@@ -30,6 +30,14 @@ pub fn transform2_to_3(mut json: JsonMap) -> JsonMap {
     }
     json.insert("packages".into(), new_obj.into());
   }
+  if let Some(serde_json::Value::Object(remote_obj)) = json.get_mut("remote") {
+    for (_, value) in remote_obj.iter_mut() {
+      if let serde_json::Value::String(value) = value {
+        *value = format!("sha256-{}", value);
+      }
+    }
+  }
+
   json
 }
 
@@ -89,8 +97,8 @@ mod test {
     assert_eq!(result, serde_json::from_value(json!({
       "version": "3",
       "remote": {
-        "https://github.com/": "asdf",
-        "https://github.com/mod.ts": "asdf2",
+        "https://github.com/": "sha256-asdf",
+        "https://github.com/mod.ts": "sha256-asdf2",
       },
       "packages": {
         "specifiers": {

--- a/src/transforms.rs
+++ b/src/transforms.rs
@@ -1,0 +1,112 @@
+pub type JsonMap = serde_json::Map<String, serde_json::Value>;
+
+pub fn transform1_to_2(json: JsonMap) -> JsonMap {
+  let mut new_map = JsonMap::new();
+  new_map.insert("version".to_string(), "2".into());
+  new_map.insert("remote".to_string(), json.into());
+  new_map
+}
+
+pub fn transform2_to_3(mut json: JsonMap) -> JsonMap {
+  json.insert("version".into(), "3".into());
+  if let Some(serde_json::Value::Object(mut npm_obj)) = json.remove("npm") {
+    let mut new_obj = JsonMap::new();
+    if let Some(packages) = npm_obj.remove("packages") {
+      new_obj.insert("npm".into(), packages);
+    }
+    if let Some(serde_json::Value::Object(specifiers)) =
+      npm_obj.remove("specifiers")
+    {
+      let mut new_specifiers = JsonMap::new();
+      for (key, value) in specifiers {
+        if let serde_json::Value::String(value) = value {
+          new_specifiers
+            .insert(format!("npm:{}", key), format!("npm:{}", value).into());
+        }
+      }
+      if !new_specifiers.is_empty() {
+        new_obj.insert("specifiers".into(), new_specifiers.into());
+      }
+    }
+    json.insert("packages".into(), new_obj.into());
+  }
+  json
+}
+
+#[cfg(test)]
+mod test {
+  use pretty_assertions::assert_eq;
+  use serde_json::json;
+
+  use super::*;
+
+  #[test]
+  fn test_transforms_1_to_2() {
+    let data: JsonMap = serde_json::from_value(json!({
+      "https://github.com/": "asdf",
+      "https://github.com/mod.ts": "asdf2",
+    }))
+    .unwrap();
+    let result = transform1_to_2(data);
+    assert_eq!(
+      result,
+      serde_json::from_value(json!({
+        "version": "2",
+        "remote": {
+          "https://github.com/": "asdf",
+          "https://github.com/mod.ts": "asdf2",
+        }
+      }))
+      .unwrap()
+    );
+  }
+
+  #[test]
+  fn test_transforms_2_to_3() {
+    let data: JsonMap = serde_json::from_value(json!({
+      "version": "2",
+      "remote": {
+        "https://github.com/": "asdf",
+        "https://github.com/mod.ts": "asdf2",
+      },
+      "npm": {
+        "specifiers": {
+          "nanoid": "nanoid@3.3.4",
+        },
+        "packages": {
+          "nanoid@3.3.4": {
+            "integrity": "sha512-MqBkQh/OHTS2egovRtLk45wEyNXwF+cokD+1YPf9u5VfJiRdAiRwB2froX5Co9Rh20xs4siNPm8naNotSD6RBw==",
+            "dependencies": {}
+          },
+          "picocolors@1.0.0": {
+            "integrity": "sha512-foobar",
+            "dependencies": {}
+          }
+        }
+      }
+    })).unwrap();
+    let result = transform2_to_3(data);
+    assert_eq!(result, serde_json::from_value(json!({
+      "version": "3",
+      "remote": {
+        "https://github.com/": "asdf",
+        "https://github.com/mod.ts": "asdf2",
+      },
+      "packages": {
+        "specifiers": {
+          "npm:nanoid": "npm:nanoid@3.3.4",
+        },
+        "npm": {
+          "nanoid@3.3.4": {
+            "integrity": "sha512-MqBkQh/OHTS2egovRtLk45wEyNXwF+cokD+1YPf9u5VfJiRdAiRwB2froX5Co9Rh20xs4siNPm8naNotSD6RBw==",
+            "dependencies": {}
+          },
+          "picocolors@1.0.0": {
+            "integrity": "sha512-foobar",
+            "dependencies": {}
+          }
+        }
+      }
+    })).unwrap());
+  }
+}


### PR DESCRIPTION
This is a proposal that has not yet been agreed upon.

1. Moves `npm -> specifiers` to `packages -> specifiers`. Each specifier and destination is now prefixed with `npm:`.
    - This generalizes with `deno:` specifiers and allows mapping `deno:` specifiers to `npm:`.
2. Moves `npm -> packages` to `packages -> npm`.

`deno:` specifiers will then be stored under `packages -> specifiers`.

Example output:

```json
{
  "version": "3",
  "packages": {
    "specifiers": {
      "npm:nanoid": "npm:nanoid@3.3.4",
      "deno:path": "deno:path@1.0.0",
      "deno:ts-morph@^11": "npm:ts-morph@11.0.0",
      "deno:@scope/pkg@~1.0": "deno:@scope/pkg@1.0.5"
    },
    "npm": {
      "nanoid@3.3.4": {
        "integrity": "sha512-MqBkQh/OHTS2egovRtLk45wEyNXwF+cokD+1YPf9u5VfJiRdAiRwB2froX5Co9Rh20xs4siNPm8naNotSD6RBw==",
        "dependencies": {}
      },
      "picocolors@1.0.0": {
        "integrity": "sha512-foobar",
        "dependencies": {}
      }
    }
  },
  "remote": {
    "https://github.com/": "MqBkQh/OHTS2egovRtLk45wEyNXwF+cokD+1YPf9u5VfJiRdAiRwB2froX5Co9Rh20xs4siNPm8naNotSD6RBw==",
    "https://github.com/mod.ts": "MqBkQh/OHTS2egovRtLk45wEyNXwF+cokD+1YPf9u5VfJiRdAiRwB2froX5Co9Rh20xs4siNPm8naNotSD6RBw=="
  }
}
```