### PR TITLE
fix: remove `package->specifiers` value's `npm:<pkg-name>@` prefix in v2 -> v3

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -769,7 +769,7 @@ mod tests {
     assert_eq!(lockfile.content.packages.npm.len(), 2);
     assert_eq!(
       lockfile.content.packages.specifiers,
-      BTreeMap::from([("npm:nanoid".to_string(), "nanoid@3.3.4".to_string()),])
+      BTreeMap::from([("npm:nanoid".to_string(), "3.3.4".to_string()),])
     );
     assert_eq!(lockfile.content.remote.len(), 2);
   }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -687,7 +687,7 @@ mod tests {
   "version": "3",
   "packages": {
     "specifiers": {
-      "deno:path": "deno:@std/path@0.75.0"
+      "deno:path": "@std/path@0.75.0"
     }
   },
   "remote": {}
@@ -697,17 +697,17 @@ mod tests {
     .unwrap();
     lockfile.insert_package_specifier(
       "deno:path".to_string(),
-      "deno:@std/path@0.75.0".to_string(),
+      "@std/path@0.75.0".to_string(),
     );
     assert!(!lockfile.has_content_changed);
     lockfile.insert_package_specifier(
       "deno:path".to_string(),
-      "deno:@std/path@0.75.1".to_string(),
+      "@std/path@0.75.1".to_string(),
     );
     assert!(lockfile.has_content_changed);
     lockfile.insert_package_specifier(
       "deno:@foo/bar@^2".to_string(),
-      "deno:@foo/bar@2.1.2".to_string(),
+      "@foo/bar@2.1.2".to_string(),
     );
     assert_eq!(
       lockfile.as_json_string(),
@@ -715,8 +715,8 @@ mod tests {
   "version": "3",
   "packages": {
     "specifiers": {
-      "deno:@foo/bar@^2": "deno:@foo/bar@2.1.2",
-      "deno:path": "deno:@std/path@0.75.1"
+      "deno:@foo/bar@^2": "@foo/bar@2.1.2",
+      "deno:path": "@std/path@0.75.1"
     }
   },
   "remote": {}
@@ -769,10 +769,7 @@ mod tests {
     assert_eq!(lockfile.content.packages.npm.len(), 2);
     assert_eq!(
       lockfile.content.packages.specifiers,
-      BTreeMap::from([(
-        "npm:nanoid".to_string(),
-        "npm:nanoid@3.3.4".to_string()
-      ),])
+      BTreeMap::from([("npm:nanoid".to_string(), "nanoid@3.3.4".to_string()),])
     );
     assert_eq!(lockfile.content.remote.len(), 2);
   }

--- a/src/transforms.rs
+++ b/src/transforms.rs
@@ -19,10 +19,7 @@ pub fn transform2_to_3(mut json: JsonMap) -> JsonMap {
     {
       let mut new_specifiers = JsonMap::new();
       for (key, value) in specifiers {
-        if let serde_json::Value::String(value) = value {
-          new_specifiers
-            .insert(format!("npm:{}", key), format!("npm:{}", value).into());
-        }
+        new_specifiers.insert(format!("npm:{}", key), value);
       }
       if !new_specifiers.is_empty() {
         new_obj.insert("specifiers".into(), new_specifiers.into());
@@ -102,7 +99,7 @@ mod test {
       },
       "packages": {
         "specifiers": {
-          "npm:nanoid": "npm:nanoid@3.3.4",
+          "npm:nanoid": "nanoid@3.3.4",
         },
         "npm": {
           "nanoid@3.3.4": {

--- a/src/transforms.rs
+++ b/src/transforms.rs
@@ -19,7 +19,12 @@ pub fn transform2_to_3(mut json: JsonMap) -> JsonMap {
     {
       let mut new_specifiers = JsonMap::new();
       for (key, value) in specifiers {
-        new_specifiers.insert(format!("npm:{}", key), value);
+        if let serde_json::Value::String(value) = value {
+          if let Some(value_index) = value.rfind('@') {
+            new_specifiers
+              .insert(format!("npm:{}", key), value[value_index + 1..].into());
+          }
+        }
       }
       if !new_specifiers.is_empty() {
         new_obj.insert("specifiers".into(), new_specifiers.into());
@@ -77,6 +82,7 @@ mod test {
       "npm": {
         "specifiers": {
           "nanoid": "nanoid@3.3.4",
+          "@types/node": "@types/node@1.0.0-next",
         },
         "packages": {
           "nanoid@3.3.4": {
@@ -99,7 +105,8 @@ mod test {
       },
       "packages": {
         "specifiers": {
-          "npm:nanoid": "nanoid@3.3.4",
+          "npm:nanoid": "3.3.4",
+          "npm:@types/node": "1.0.0-next",
         },
         "npm": {
           "nanoid@3.3.4": {


### PR DESCRIPTION
The example in https://github.com/denoland/deno_lockfile/pull/8 can instead be a redirect from `"deno:ts-morph@^11": "npm:ts-morph@^11"`, then a specifiers entry `"npm:ts-morph@^11": "11.0.0"` -- This is much easier to manage.