### PR TITLE
fix: include all jsr deps in lockfile

### DIFF
--- a/src/graphs.rs
+++ b/src/graphs.rs
@@ -32,11 +32,13 @@ impl LockfileNpmPackageId {
 #[derive(Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
 struct LockfilePkgReq(String);
 
+#[derive(Debug)]
 enum LockfileGraphPackage {
   Jsr(LockfileJsrGraphPackage),
   Npm(LockfileNpmGraphPackage),
 }
 
+#[derive(Debug)]
 struct LockfileNpmGraphPackage {
   /// Root ids that transitively reference this package.
   root_ids: HashSet<LockfilePkgId>,
@@ -44,7 +46,7 @@ struct LockfileNpmGraphPackage {
   dependencies: BTreeMap<String, LockfileNpmPackageId>,
 }
 
-#[derive(Default)]
+#[derive(Debug, Default)]
 struct LockfileJsrGraphPackage {
   /// Root ids that transitively reference this package.
   root_ids: HashSet<LockfilePkgId>,
@@ -286,21 +288,19 @@ impl<FNvToJsrUrl: Fn(&str) -> Option<String>>
     for (id, package) in self.packages {
       match package {
         LockfileGraphPackage::Jsr(package) => {
-          if !package.dependencies.is_empty() {
-            packages.jsr.insert(
-              match id {
-                LockfilePkgId::Jsr(nv) => nv.0,
-                LockfilePkgId::Npm(_) => unreachable!(),
-              },
-              crate::JsrPackageInfo {
-                dependencies: package
-                  .dependencies
-                  .into_iter()
-                  .map(|req| req.0)
-                  .collect(),
-              },
-            );
-          }
+          packages.jsr.insert(
+            match id {
+              LockfilePkgId::Jsr(nv) => nv.0,
+              LockfilePkgId::Npm(_) => unreachable!(),
+            },
+            crate::JsrPackageInfo {
+              dependencies: package
+                .dependencies
+                .into_iter()
+                .map(|req| req.0)
+                .collect(),
+            },
+          );
         }
         LockfileGraphPackage::Npm(package) => {
           packages.npm.insert(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -165,7 +165,7 @@ pub struct PackagesContent {
 
 impl PackagesContent {
   fn is_empty(&self) -> bool {
-    self.specifiers.is_empty() && self.npm.is_empty()
+    self.specifiers.is_empty() && self.npm.is_empty() && self.jsr.is_empty()
   }
 }
 

--- a/tests/specs/config_changes/CircularJsrDep02.txt
+++ b/tests/specs/config_changes/CircularJsrDep02.txt
@@ -5,7 +5,7 @@
     "specifiers": {
       "jsr:@scope/package_a": "jsr:@scope/package_a@0.0.1",
       "jsr:@scope/package_b": "jsr:@scope/package_b@0.0.1",
-      "jsr:@scope/package_c": "jsr:@scope/package_b@0.0.1"
+      "jsr:@scope/package_c": "jsr:@scope/package_c@0.0.1"
     },
     "jsr": {
       "@scope/package_a@0.0.1": {

--- a/tests/specs/config_changes/NoConfigMaintains.txt
+++ b/tests/specs/config_changes/NoConfigMaintains.txt
@@ -24,7 +24,8 @@
         "dependencies": [
           "jsr:@scope/package_a"
         ]
-      }
+      },
+      "@scope/package_orphan@0.0.1": {}
     },
     "npm": {
       "@example/orphan": {
@@ -225,7 +226,8 @@
         "dependencies": [
           "jsr:@scope/package_a"
         ]
-      }
+      },
+      "@scope/package_orphan@0.0.1": {}
     },
     "npm": {
       "@example/orphan": {

--- a/tests/specs/config_changes/NoConfigWorkspaceMaintains.txt
+++ b/tests/specs/config_changes/NoConfigWorkspaceMaintains.txt
@@ -24,7 +24,8 @@
         "dependencies": [
           "jsr:@scope/package_a"
         ]
-      }
+      },
+      "@scope/package_orphan@0.0.1": {}
     },
     "npm": {
       "@example/orphan": {
@@ -229,7 +230,8 @@
         "dependencies": [
           "jsr:@scope/package_a"
         ]
-      }
+      },
+      "@scope/package_orphan@0.0.1": {}
     },
     "npm": {
       "@example/orphan": {

--- a/tests/specs/config_changes/NoNpmMaintainsNpm.txt
+++ b/tests/specs/config_changes/NoNpmMaintainsNpm.txt
@@ -207,6 +207,9 @@
       "jsr:@scope/package_orphan": "jsr:@scope/package_orphan@0.0.1",
       "npm:ts-morph": "npm:ts-morph@21.0.1"
     },
+    "jsr": {
+      "@scope/package_orphan@0.0.1": {}
+    },
     "npm": {
       "@example/orphan": {
         "integrity": "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==",

--- a/tests/specs/config_changes/NoNpmWorkspaceMaintainsNpm.txt
+++ b/tests/specs/config_changes/NoNpmWorkspaceMaintainsNpm.txt
@@ -24,7 +24,8 @@
         "dependencies": [
           "jsr:@scope/package_a"
         ]
-      }
+      },
+      "@scope/package_orphan@0.0.1": {}
     },
     "npm": {
       "@example/orphan": {
@@ -236,7 +237,8 @@
         "dependencies": [
           "jsr:@scope/package_a"
         ]
-      }
+      },
+      "@scope/package_orphan@0.0.1": {}
     },
     "npm": {
       "@example/orphan": {
@@ -421,6 +423,9 @@
   "packages": {
     "specifiers": {
       "jsr:@scope/package_orphan": "jsr:@scope/package_orphan@0.0.1"
+    },
+    "jsr": {
+      "@scope/package_orphan@0.0.1": {}
     },
     "npm": {
       "@example/orphan": {

--- a/tests/specs/config_changes/RemovedConfigRemoves.txt
+++ b/tests/specs/config_changes/RemovedConfigRemoves.txt
@@ -206,6 +206,9 @@
     "specifiers": {
       "jsr:@scope/package_orphan": "jsr:@scope/package_orphan@0.0.1"
     },
+    "jsr": {
+      "@scope/package_orphan@0.0.1": {}
+    },
     "npm": {
       "@example/orphan": {
         "integrity": "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==",

--- a/tests/specs/config_changes/RemovedDenoJsonRemoves.txt
+++ b/tests/specs/config_changes/RemovedDenoJsonRemoves.txt
@@ -212,6 +212,9 @@
       "jsr:@scope/package_orphan": "jsr:@scope/package_orphan@0.0.1",
       "npm:ts-morph": "npm:ts-morph@21.0.1"
     },
+    "jsr": {
+      "@scope/package_orphan@0.0.1": {}
+    },
     "npm": {
       "@example/orphan": {
         "integrity": "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==",

--- a/tests/specs/config_changes/RemovedPackageJsonRemoves.txt
+++ b/tests/specs/config_changes/RemovedPackageJsonRemoves.txt
@@ -227,7 +227,8 @@
         "dependencies": [
           "jsr:@scope/package_a"
         ]
-      }
+      },
+      "@scope/package_orphan@0.0.1": {}
     },
     "npm": {
       "@example/orphan": {

--- a/tests/specs/config_changes/RemovingOakThenDax.txt
+++ b/tests/specs/config_changes/RemovingOakThenDax.txt
@@ -407,6 +407,10 @@
           "jsr:@std/streams@0.210.0"
         ]
       },
+      "@dsherret/which@0.0.1": {},
+      "@std/assert@0.210.0": {},
+      "@std/bytes@0.210.0": {},
+      "@std/fmt@0.210.0": {},
       "@std/fs@0.210.0": {
         "dependencies": [
           "jsr:@std/assert@^0.210.0",
@@ -431,6 +435,8 @@
           "jsr:@std/io@^0.210.0"
         ]
       },
+      "@zome_unreferenced/package@0.1.0": {},
+      "@zome_unreferenced/package_b@0.1.0": {},
       "jsr:@zome_unreferenced/package@0.1.0": {
         "dependencies": [
           "jsr:@zome_unreferenced/package_b"
@@ -653,6 +659,8 @@
       "jsr:@zome_unreferenced/package_b": "jsr:@zome_unreferenced/package_b@0.1.0"
     },
     "jsr": {
+      "@zome_unreferenced/package@0.1.0": {},
+      "@zome_unreferenced/package_b@0.1.0": {},
       "jsr:@zome_unreferenced/package@0.1.0": {
         "dependencies": [
           "jsr:@zome_unreferenced/package_b"

--- a/tests/specs/config_changes/RemovingWorkspaceDep.txt
+++ b/tests/specs/config_changes/RemovingWorkspaceDep.txt
@@ -419,6 +419,10 @@
           "jsr:@std/streams@0.210.0"
         ]
       },
+      "@dsherret/which@0.0.1": {},
+      "@std/assert@0.210.0": {},
+      "@std/bytes@0.210.0": {},
+      "@std/fmt@0.210.0": {},
       "@std/fs@0.210.0": {
         "dependencies": [
           "jsr:@std/assert@^0.210.0",
@@ -443,6 +447,8 @@
           "jsr:@std/io@^0.210.0"
         ]
       },
+      "@zome_unreferenced/package@0.1.0": {},
+      "@zome_unreferenced/package_b@0.1.0": {},
       "jsr:@zome_unreferenced/package@0.1.0": {
         "dependencies": [
           "jsr:@zome_unreferenced/package_b"

--- a/tests/specs/config_changes/RemovingWorkspaceMember.txt
+++ b/tests/specs/config_changes/RemovingWorkspaceMember.txt
@@ -413,6 +413,10 @@
           "jsr:@std/streams@0.210.0"
         ]
       },
+      "@dsherret/which@0.0.1": {},
+      "@std/assert@0.210.0": {},
+      "@std/bytes@0.210.0": {},
+      "@std/fmt@0.210.0": {},
       "@std/fs@0.210.0": {
         "dependencies": [
           "jsr:@std/assert@^0.210.0",
@@ -437,6 +441,8 @@
           "jsr:@std/io@^0.210.0"
         ]
       },
+      "@zome_unreferenced/package@0.1.0": {},
+      "@zome_unreferenced/package_b@0.1.0": {},
       "jsr:@zome_unreferenced/package@0.1.0": {
         "dependencies": [
           "jsr:@zome_unreferenced/package_b"

--- a/tests/specs/config_changes/ShiftingDepsDifferentWorkspaceMember.txt
+++ b/tests/specs/config_changes/ShiftingDepsDifferentWorkspaceMember.txt
@@ -11,7 +11,8 @@
         "dependencies": [
           "jsr:@dsherret/which@0.0.1"
         ]
-      }
+      },
+      "@dsherret/which@0.0.1": {}
     }
   },
   "remote": {
@@ -49,7 +50,8 @@
         "dependencies": [
           "jsr:@dsherret/which@0.0.1"
         ]
-      }
+      },
+      "@dsherret/which@0.0.1": {}
     }
   },
   "remote": {
@@ -91,7 +93,8 @@
         "dependencies": [
           "jsr:@dsherret/which@0.0.1"
         ]
-      }
+      },
+      "@dsherret/which@0.0.1": {}
     }
   },
   "remote": {


### PR DESCRIPTION
Follow-up to https://github.com/denoland/deno_lockfile/pull/14. I'll include the version manifest integrity in a future PR.