### PR TITLE
fix: always insert jsr deps

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -664,15 +664,10 @@ impl Lockfile {
     deps: impl Iterator<Item = String>,
   ) {
     let mut is_new_insert = false;
-    let package = self
-      .content
-      .packages
-      .jsr
-      .entry(name)
-      .or_insert_with(|| {
-        is_new_insert = true;
-        Default::default()
-      });
+    let package = self.content.packages.jsr.entry(name).or_insert_with(|| {
+      is_new_insert = true;
+      Default::default()
+    });
 
     let start_count = package.dependencies.len();
     package.dependencies.extend(deps);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -663,16 +663,23 @@ impl Lockfile {
     name: String,
     deps: impl Iterator<Item = String>,
   ) {
-    let mut deps = deps.peekable();
-    if deps.peek().is_none() {
-      return; // skip, don't bother adding
-    }
+    let mut is_new_insert = false;
+    let package = self
+      .content
+      .packages
+      .jsr
+      .entry(name.clone())
+      .or_insert_with(|| {
+        is_new_insert = true;
+        Default::default()
+      });
 
-    let package = self.content.packages.jsr.entry(name).or_default();
     let start_count = package.dependencies.len();
     package.dependencies.extend(deps);
     let end_count = package.dependencies.len();
-    if start_count != end_count {
+
+    // Update has_content_changed if there's a new insert or the dependencies count changed.
+    if is_new_insert || start_count != end_count {
       self.has_content_changed = true;
     }
   }
@@ -1117,5 +1124,33 @@ mod tests {
       )])
     );
     assert_eq!(lockfile.content.remote.len(), 2);
+  }
+
+  #[test]
+  fn insert_package_deps_changes_empty_insert() {
+    let content: &str = r#"{
+      "version": "2",
+      "remote": {}
+    }"#;
+    let file_path = PathBuf::from("lockfile.json");
+    let mut lockfile =
+      Lockfile::with_lockfile_content(file_path, content, false).unwrap();
+
+    assert!(!lockfile.has_content_changed);
+    lockfile.insert_package_deps("dep".to_string(), vec![].into_iter());
+    // has changed even though it was empty
+    assert!(lockfile.has_content_changed);
+
+    // now try inserting the same package
+    lockfile.has_content_changed = false;
+    lockfile.insert_package_deps("dep".to_string(), vec![].into_iter());
+    assert!(!lockfile.has_content_changed);
+
+    // now with new deps
+    lockfile.insert_package_deps(
+      "dep".to_string(),
+      vec!["dep2".to_string()].into_iter(),
+    );
+    assert!(lockfile.has_content_changed);
   }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -678,7 +678,6 @@ impl Lockfile {
     package.dependencies.extend(deps);
     let end_count = package.dependencies.len();
 
-    // Update has_content_changed if there's a new insert or the dependencies count changed.
     if is_new_insert || start_count != end_count {
       self.has_content_changed = true;
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -668,7 +668,7 @@ impl Lockfile {
       .content
       .packages
       .jsr
-      .entry(name.clone())
+      .entry(name)
       .or_insert_with(|| {
         is_new_insert = true;
         Default::default()


### PR DESCRIPTION
Part of https://github.com/denoland/deno/pull/22359 -- I should have tested all this in integration earlier. Again, in the future we're always going to be adding an integrity here and as part of a previous fix I did it expects all the jsr deps to exist in the lockfile now.