### PR TITLE
refactor(BREAKING): move file system functionality out of lockfile crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -44,7 +44,6 @@ dependencies = [
  "serde",
  "serde_json",
  "sha2",
- "temp-dir",
  "thiserror",
 ]
 
@@ -172,12 +171,6 @@ dependencies = [
  "quote",
  "unicode-ident",
 ]
-
-[[package]]
-name = "temp-dir"
-version = "0.1.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af547b166dd1ea4b472165569fc456cfb6818116f854690b0ff205e636523dab"
 
 [[package]]
 name = "thiserror"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,4 +15,3 @@ thiserror = "1.0.40"
 
 [dev-dependencies]
 pretty_assertions = "1.4.0"
-temp-dir = "0.1.11"

--- a/src/error.rs
+++ b/src/error.rs
@@ -4,12 +4,6 @@ use thiserror::Error;
 
 #[derive(Debug, Error)]
 pub enum LockfileError {
-  #[error(transparent)]
-  Io(#[from] std::io::Error),
-
-  #[error("Unable to read lockfile. {0}")]
-  ReadError(String),
-
   #[error("Unable to parse contents of lockfile. {0}: {1:#}")]
   ParseError(String, serde_json::Error),
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -4,6 +4,9 @@ use thiserror::Error;
 
 #[derive(Debug, Error)]
 pub enum LockfileError {
+  #[error("Unable to read lockfile. {0}")]
+  ReadError(String),
+
   #[error("Unable to parse contents of lockfile. {0}: {1:#}")]
   ParseError(String, serde_json::Error),
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -808,8 +808,8 @@ mod tests {
   fn check_or_insert_lockfile() {
     let mut lockfile = setup(false).unwrap();
 
-    // false since overwrite was false and there's no changes
-    assert!(!lockfile.resolve_write_bytes().is_some());
+    // none since overwrite was false and there's no changes
+    assert!(lockfile.resolve_write_bytes().is_none());
 
     lockfile.insert(
       "https://deno.land/std@0.71.0/textproto/mod.ts",

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -290,6 +290,10 @@ impl Lockfile {
       return Ok(Lockfile::new_empty(filename, overwrite));
     }
 
+    if content.trim().is_empty() {
+      return Err(Error::ReadError("Lockfile was empty.".to_string()));
+    }
+
     let value: serde_json::Map<String, serde_json::Value> =
       serde_json::from_str(content).map_err(|err| {
         Error::ParseError(filename.display().to_string(), err)
@@ -1090,5 +1094,18 @@ mod tests {
       vec!["dep2".to_string()].into_iter(),
     );
     assert!(lockfile.has_content_changed);
+  }
+
+  #[test]
+  fn empty_lockfile_nicer_error() {
+    let content: &str = r#"  "#;
+    let file_path = PathBuf::from("lockfile.json");
+    let err = Lockfile::with_lockfile_content(file_path, content, false)
+      .err()
+      .unwrap();
+    assert_eq!(
+      err.to_string(),
+      "Unable to read lockfile. Lockfile was empty."
+    );
   }
 }

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -183,8 +183,7 @@ fn verify_packages_content(packages: &PackagesContent) {
 fn adding_workspace_does_not_cause_content_changes() {
   // should maintain the has_content_changed flag when lockfile empty
   {
-    let mut lockfile =
-      Lockfile::new(PathBuf::from("./deno.lock"), true).unwrap();
+    let mut lockfile = Lockfile::new_empty(PathBuf::from("./deno.lock"), true);
 
     assert!(!lockfile.has_content_changed);
     lockfile.set_workspace_config(SetWorkspaceConfigOptions {
@@ -203,8 +202,7 @@ fn adding_workspace_does_not_cause_content_changes() {
 
   // should maintain has_content_changed flag when true and lockfile is empty
   {
-    let mut lockfile =
-      Lockfile::new(PathBuf::from("./deno.lock"), true).unwrap();
+    let mut lockfile = Lockfile::new_empty(PathBuf::from("./deno.lock"), true);
     lockfile.has_content_changed = true;
     lockfile.set_workspace_config(SetWorkspaceConfigOptions {
       no_config: false,
@@ -222,8 +220,7 @@ fn adding_workspace_does_not_cause_content_changes() {
 
   // should not maintain the has_content_changed flag when lockfile is not empty
   {
-    let mut lockfile =
-      Lockfile::new(PathBuf::from("./deno.lock"), true).unwrap();
+    let mut lockfile = Lockfile::new_empty(PathBuf::from("./deno.lock"), true);
     lockfile
       .content
       .redirects


### PR DESCRIPTION
We should leave fs operations up to the caller so that they don't accidentally use methods that interact with the real file system instead of a virtual file system for example (ex. deno compile).

This will also help use reuse the "atomic write" functionality in the CLI.