### PR TITLE
fix: deserialize v3 straight

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -49,6 +49,8 @@ pub enum DeserializationError {
   InvalidNpmPackageDependency(String),
   #[error("Invalid package specifier '{0}'. Lockfile may be corrupt or you might be using an old version of Deno.")]
   InvalidPackageSpecifier(String),
+  #[error("Invalid jsr dependency '{dependency}' for '{package}'. Lockfile may be corrupt or you might be using an old version of Deno.")]
+  InvalidJsrDependency { package: String, dependency: String },
   #[error("npm package '{0}' was not found and could not have its version resolved. Lockfile may be corrupt.")]
   MissingPackage(String),
 }


### PR DESCRIPTION
v4 is a somewhat lossy format and so we can't actually work with v3 by upgrading to v4 and then downgrading.

Ref: https://github.com/denoland/deno_graph/pull/513#issuecomment-2299791596