### PR TITLE
fix: remove peer dependents on package removal

### DIFF
--- a/src/graphs.rs
+++ b/src/graphs.rs
@@ -272,15 +272,12 @@ impl LockfilePackageGraph {
         if let Some(id) = self.root_packages.get(&pending_req) {
           if let LockfilePkgId::Npm(id) = id {
             if let Some(first_part) = id.parts().next() {
+              let first_part = first_part.replace("/", "+");
               for (req, id) in &self.root_packages {
                 if let LockfilePkgId::Npm(id) = &id {
                   // be a bit aggressive and remove any npm packages that
                   // have this package as a peer dependency
-                  if id
-                    .parts()
-                    .skip(1)
-                    .any(|part| part.replace("+", "/") == first_part)
-                  {
+                  if id.parts().skip(1).any(|part| part == first_part) {
                     let has_visited = visited_root_packages.insert(req.clone());
                     if has_visited {
                       pending_reqs.push_back(req.clone());

--- a/src/graphs.rs
+++ b/src/graphs.rs
@@ -276,7 +276,11 @@ impl LockfilePackageGraph {
                 if let LockfilePkgId::Npm(id) = &id {
                   // be a bit aggressive and remove any npm packages that
                   // have this package as a peer dependency
-                  if id.parts().skip(1).any(|part| part == first_part) {
+                  if id
+                    .parts()
+                    .skip(1)
+                    .any(|part| part.replace("+", "/") == first_part)
+                  {
                     let has_visited = visited_root_packages.insert(req.clone());
                     if has_visited {
                       pending_reqs.push_back(req.clone());


### PR DESCRIPTION
The logic was actually already there, it just was never working because in lockfile package IDs we format peer dependents like `@test+foo@1.0.0` instead of `@test/foo@1.0.0`