### PR TITLE
fix: support bundle dependencies

### DIFF
--- a/src/transforms.rs
+++ b/src/transforms.rs
@@ -306,6 +306,10 @@ pub async fn transform4_to_5(
         value.insert("optionalPeers".into(), new_optional_peer_deps.into());
       }
 
+      for bundle_dep in &result.bundle_dependencies {
+        existing_deps.remove(bundle_dep);
+      }
+
       if existing_deps.is_empty() {
         value.remove("dependencies");
       } else {
@@ -347,6 +351,7 @@ pub async fn transform4_to_5(
 #[serde(rename_all = "camelCase", default)]
 pub struct Lockfile5NpmInfo {
   pub tarball_url: Option<String>,
+  pub bundle_dependencies: Vec<String>,
   pub optional_dependencies: BTreeMap<String, String>,
   pub optional_peers: BTreeMap<String, String>,
   pub cpu: Vec<String>,

--- a/tests/registry_data/@c__pkg@2.0.5.json
+++ b/tests/registry_data/@c__pkg@2.0.5.json
@@ -1,0 +1,4 @@
+{
+  "tarballUrl": "https://fake-registry.com/a/pkg-2.1.5.tgz",
+  "bundleDependencies": ["@b/pkg"]
+}

--- a/tests/spec_test.rs
+++ b/tests/spec_test.rs
@@ -289,7 +289,6 @@ impl NpmPackageInfoProvider for TestNpmPackageInfoProvider {
         if path.exists() {
           let text = std::fs::read_to_string(path).unwrap();
           let info: Lockfile5NpmInfo = serde_json::from_str(&text).unwrap();
-          eprintln!("INFO: {:?}", info);
           self
             .cache
             .borrow_mut()

--- a/tests/spec_test.rs
+++ b/tests/spec_test.rs
@@ -289,6 +289,7 @@ impl NpmPackageInfoProvider for TestNpmPackageInfoProvider {
         if path.exists() {
           let text = std::fs::read_to_string(path).unwrap();
           let info: Lockfile5NpmInfo = serde_json::from_str(&text).unwrap();
+          eprintln!("INFO: {:?}", info);
           self
             .cache
             .borrow_mut()

--- a/tests/specs/transforms/upgrades_v3_npm_bundle_deps.txt
+++ b/tests/specs/transforms/upgrades_v3_npm_bundle_deps.txt
@@ -1,0 +1,36 @@
+# original
+{
+  "version": "3",
+  "packages": {
+    "npm": {
+      "@c/pkg@2.1.5": {
+        "integrity": "sha512-a1",
+        "dependencies": {
+          "@b/pkg": "@b/pkg@2.0.5"
+        }
+      },
+      "@b/pkg@2.0.5": {
+        "integrity": "sha512-b1"
+      }
+    }
+  },
+  "remote": {}
+}
+
+# output (this keeps @b/pkg, which is not ideal, but fine)
+{
+  "version": "5",
+  "npm": {
+    "@b/pkg@2.0.5": {
+      "integrity": "sha512-b1",
+      "deprecated": true,
+      "tarball": "https://fake-registry.com/b/pkg-2.0.5.tgz"
+    },
+    "@c/pkg@2.1.5": {
+      "integrity": "sha512-a1",
+      "dependencies": [
+        "@b/pkg"
+      ]
+    }
+  }
+}


### PR DESCRIPTION
Supports bundleDependencies by just excluding them from the lockfile. I'm not sure there's any reason to store them.